### PR TITLE
Additional Mutators

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class User extends Model
      * {@inheritDoc}
      */
     protected $table = 'users';
-    
+
     /**
      * {@inheritDoc}
      */
@@ -54,10 +54,19 @@ class User extends Model
 
 This will automatically serialize/unserialize the `id` attribute on the `User` model when
 getting/setting the attribute from the database. This allows you to no longer need to set
-accessors/mutator methods on the model directly. 
+accessors/mutator methods on the model directly.
 
 > **Note:**  Unlike the built in Laravel accessors/mutators,
 this package will serialize the attribute values when they are passed to an Eloquent query builder.
+
+Included Mutators
+-----------------
+
+- `uuid_v1_binary` Will take a uuid version 1, re-order its bytes so that if uuidA was generated before uuidB, then storedUuidA < storedUuidB, and store it in the database as 16 bytes of data. For more information on the re-ordering of bytes, see: https://www.percona.com/blog/2014/12/19/store-uuid-optimized-way/.
+- `ip_binary` Will take a string representation of an IPv4 or IPv6 and store it as 16 bytes in the database.
+- `encrypt_string` Will take a non encrypted string and encrypt it when going to the database.
+- `hex_binary` Will take any hexadecimal string attribute and store it as binary data.
+- `unix_timestamp` Will take a Carbon date but store it as an integer unix timestamp.
 
 Creating Custom Mutators
 ------------------------
@@ -69,7 +78,7 @@ To define a custom mutator, you'll need to create a class that implements
 any caching logic at the mutator level.
 
 When building and registering a Mutator, it is important to know that they
-are resolved automatically from the Laravel IOC container, which means you may create 
+are resolved automatically from the Laravel IOC container, which means you may create
 service providers for them if they require custom constructor arguments.
 
 ```php

--- a/config/config.php
+++ b/config/config.php
@@ -8,5 +8,7 @@ return [
         'uuid_v1_binary' => \Weebly\Mutate\Mutators\UuidV1BinaryMutator::class,
         'ip_binary'      => \Weebly\Mutate\Mutators\IpBinaryMutator::class,
         'encrypt_string' => \Weebly\Mutate\Mutators\EncryptStringMutator::class,
+        'hex_binary'     => \Weebly\Mutate\Mutators\HexBinaryMutator::class,
+        'unix_timestamp' => \Weebly\Mutate\Mutators\UnixTimestampMutator::class,
     ],
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -2,7 +2,7 @@
 
 return [
     'enabled' => [
-        /**
+        /*
          * Eloquent mutator providers...
          */
         'uuid_v1_binary' => \Weebly\Mutate\Mutators\UuidV1BinaryMutator::class,

--- a/src/Mutators/HexBinaryMutator.php
+++ b/src/Mutators/HexBinaryMutator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Weebly\Mutate\Mutators;
+
+use Weebly\Mutate\Exceptions\MutateException;
+
+/**
+ * Presents an attribute as a hexadecimal string.
+ * Stores the attribute as a byte array.
+ */
+class HexBinaryMutator implements MutatorContract
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function serializeAttribute($value)
+    {
+        if (!\ctype_xdigit($value)) {
+
+            throw new MutateException(__METHOD__." expects the value to be serialized to be a hexadecimal string.");
+        }
+        return hex2bin($value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unserializeAttribute($value)
+    {
+        if (!$value) {
+            return null;
+        }
+        return bin2hex($value);
+    }
+}

--- a/src/Mutators/HexBinaryMutator.php
+++ b/src/Mutators/HexBinaryMutator.php
@@ -16,9 +16,9 @@ class HexBinaryMutator implements MutatorContract
     public function serializeAttribute($value)
     {
         if (! ctype_xdigit($value)) {
-
             throw new MutateException(__METHOD__.' expects the value to be serialized to be a hexadecimal string.');
         }
+
         return hex2bin($value);
     }
 
@@ -30,6 +30,7 @@ class HexBinaryMutator implements MutatorContract
         if (! $value) {
             return;
         }
+
         return bin2hex($value);
     }
 }

--- a/src/Mutators/HexBinaryMutator.php
+++ b/src/Mutators/HexBinaryMutator.php
@@ -11,24 +11,24 @@ use Weebly\Mutate\Exceptions\MutateException;
 class HexBinaryMutator implements MutatorContract
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function serializeAttribute($value)
     {
-        if (!ctype_xdigit($value)) {
+        if (! ctype_xdigit($value)) {
 
-            throw new MutateException(__METHOD__." expects the value to be serialized to be a hexadecimal string.");
+            throw new MutateException(__METHOD__.' expects the value to be serialized to be a hexadecimal string.');
         }
         return hex2bin($value);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function unserializeAttribute($value)
     {
-        if (!$value) {
-            return null;
+        if (! $value) {
+            return;
         }
         return bin2hex($value);
     }

--- a/src/Mutators/HexBinaryMutator.php
+++ b/src/Mutators/HexBinaryMutator.php
@@ -15,7 +15,7 @@ class HexBinaryMutator implements MutatorContract
      */
     public function serializeAttribute($value)
     {
-        if (! ctype_xdigit($value)) {
+        if (! ctype_xdigit($value) || strlen($value) % 2 !== 0) {
             throw new MutateException(__METHOD__.' expects the value to be serialized to be a hexadecimal string.');
         }
 

--- a/src/Mutators/HexBinaryMutator.php
+++ b/src/Mutators/HexBinaryMutator.php
@@ -15,7 +15,7 @@ class HexBinaryMutator implements MutatorContract
      */
     public function serializeAttribute($value)
     {
-        if (!\ctype_xdigit($value)) {
+        if (!ctype_xdigit($value)) {
 
             throw new MutateException(__METHOD__." expects the value to be serialized to be a hexadecimal string.");
         }

--- a/src/Mutators/UnixTimestampMutator.php
+++ b/src/Mutators/UnixTimestampMutator.php
@@ -28,7 +28,7 @@ class UnixTimestampMutator implements MutatorContract
      */
     public function unserializeAttribute($value)
     {
-        if (! $value) {
+        if (! is_int($value) && !ctype_digit($value)) {
             return;
         }
 

--- a/src/Mutators/UnixTimestampMutator.php
+++ b/src/Mutators/UnixTimestampMutator.php
@@ -28,7 +28,7 @@ class UnixTimestampMutator implements MutatorContract
      */
     public function unserializeAttribute($value)
     {
-        if (! is_int($value) && !ctype_digit($value)) {
+        if (! is_int($value) && ! ctype_digit($value)) {
             return;
         }
 

--- a/src/Mutators/UnixTimestampMutator.php
+++ b/src/Mutators/UnixTimestampMutator.php
@@ -17,7 +17,7 @@ class UnixTimestampMutator implements MutatorContract
     public function serializeAttribute($value)
     {
         if (! $value instanceof Carbon) {
-            throw new MutateException(__METHOD__." expects a Carbon\Carbon value. Received: ". print_r($value, true));
+            throw new MutateException(__METHOD__." expects a Carbon\Carbon value. Received: ".print_r($value, true));
         }
         return $value->timestamp;
     }

--- a/src/Mutators/UnixTimestampMutator.php
+++ b/src/Mutators/UnixTimestampMutator.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Weebly\Mutate\Mutators;
+
+use Carbon\Carbon;
+use Weebly\Mutate\Exceptions\MutateException;
+
+/**
+ * Presents an attribute as Carbon date object (http://carbon.nesbot.com/)
+ * Stores the attribute as unix epoch timestamp.
+ */
+class UnixTimestampMutator implements MutatorContract
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function serializeAttribute($value)
+    {
+        if (!$value instanceof Carbon) {
+            throw new MutateException(__METHOD__." expects a Carbon\Carbon value. Received: ". print_r($value, true));
+        }
+        return $value->timestamp;;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unserializeAttribute($value)
+    {
+        if (!$value) {
+            return null;
+        }
+        return Carbon::createFromTimestamp($value);
+    }
+}

--- a/src/Mutators/UnixTimestampMutator.php
+++ b/src/Mutators/UnixTimestampMutator.php
@@ -12,23 +12,23 @@ use Weebly\Mutate\Exceptions\MutateException;
 class UnixTimestampMutator implements MutatorContract
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function serializeAttribute($value)
     {
-        if (!$value instanceof Carbon) {
+        if (! $value instanceof Carbon) {
             throw new MutateException(__METHOD__." expects a Carbon\Carbon value. Received: ". print_r($value, true));
         }
         return $value->timestamp;
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function unserializeAttribute($value)
     {
-        if (!$value) {
-            return null;
+        if (! $value) {
+            return;
         }
         return Carbon::createFromTimestamp($value);
     }

--- a/src/Mutators/UnixTimestampMutator.php
+++ b/src/Mutators/UnixTimestampMutator.php
@@ -19,6 +19,7 @@ class UnixTimestampMutator implements MutatorContract
         if (! $value instanceof Carbon) {
             throw new MutateException(__METHOD__." expects a Carbon\Carbon value. Received: ".print_r($value, true));
         }
+
         return $value->timestamp;
     }
 
@@ -30,6 +31,7 @@ class UnixTimestampMutator implements MutatorContract
         if (! $value) {
             return;
         }
+
         return Carbon::createFromTimestamp($value);
     }
 }

--- a/src/Mutators/UnixTimestampMutator.php
+++ b/src/Mutators/UnixTimestampMutator.php
@@ -19,7 +19,7 @@ class UnixTimestampMutator implements MutatorContract
         if (!$value instanceof Carbon) {
             throw new MutateException(__METHOD__." expects a Carbon\Carbon value. Received: ". print_r($value, true));
         }
-        return $value->timestamp;;
+        return $value->timestamp;
     }
 
     /**

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -3,11 +3,11 @@
 namespace Weebly\Mutate;
 
 use DB;
+use Ramsey\Uuid\Uuid;
+use Orchestra\Testbench\TestCase;
+use Weebly\Mutate\Database\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Schema;
-use Orchestra\Testbench\TestCase;
-use Ramsey\Uuid\Uuid;
-use Weebly\Mutate\Database\Model;
 
 /**
  * @group integration
@@ -30,8 +30,8 @@ class MutatorTest extends TestCase
         ]);
 
         $app->singleton('mutator', function (Application $app) {
-            $mutator  = new MutatorProvider();
-            $default_mutators = require(realpath(__DIR__.'/../../config/config.php'));
+            $mutator = new MutatorProvider();
+            $default_mutators = require realpath(__DIR__.'/../../config/config.php');
             $default_mutators = $default_mutators['enabled'];
 
             $mutator->registerMutators($default_mutators);
@@ -62,9 +62,9 @@ class MutatorTest extends TestCase
 
     public function test_where()
     {
-        $id    = Uuid::uuid1()->toString();
+        $id = Uuid::uuid1()->toString();
         $model = (new TestModel())->create(['id' => $id, 'name' => 'A table']);
-        $p     = $model->find($id);
+        $p = $model->find($id);
         $this->assertEquals($id, $p->id);
 
         $p = DB::table('test_model')->where('id', $id)->first();
@@ -73,33 +73,33 @@ class MutatorTest extends TestCase
 
     public function test_find()
     {
-        $id    = Uuid::uuid1()->toString();
+        $id = Uuid::uuid1()->toString();
         $model = (new TestModel())->create(['id' => $id, 'name' => 'A table']);
-        $p     = $model->find($id);
+        $p = $model->find($id);
         $this->assertEquals($id, $p->id);
     }
 
     public function test_non_mutated_columns()
     {
-        $id    = Uuid::uuid1()->toString();
+        $id = Uuid::uuid1()->toString();
         $model = (new TestModel())->create(['id' => $id, 'name' => 'abc']);
-        $p     = $model->where('name', 'abc')->first();
+        $p = $model->where('name', 'abc')->first();
         $this->assertEquals($id, $p->id);
     }
 
     public function test_where_in()
     {
-        $id    = Uuid::uuid1()->toString();
+        $id = Uuid::uuid1()->toString();
         $model = (new TestModel())->create(['id' => $id, 'name' => 'A chair']);
-        $p     = $model->whereIn('id', [$id])->first();
+        $p = $model->whereIn('id', [$id])->first();
         $this->assertEquals($id, $p->id);
     }
 
     public function test_update()
     {
-        $id    = Uuid::uuid1()->toString();
+        $id = Uuid::uuid1()->toString();
         $model = (new TestModel())->create(['id' => $id, 'name' => 'A chair', 'location' => 'Foo']);
-        $p1    = (new TestModel())->whereIn('id', [$id])->first();
+        $p1 = (new TestModel())->whereIn('id', [$id])->first();
 
         // Update the attribute
         $model->location = 'Bar';
@@ -142,35 +142,35 @@ class MutatorTest extends TestCase
 class TestModel extends Model
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $table = 'test_model';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $guarded = [];
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public $timestamps = false;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public $incrementing = false;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $keyType = 'string';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $mutate = [
-        'id'       => 'uuid_v1_binary',
+        'id' => 'uuid_v1_binary',
         'location' => 'encrypt_string',
     ];
 }

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -38,7 +38,6 @@ class MutatorTest extends TestCase
 
             return $mutator;
         });
-
     }
 
     public function setUp()

--- a/tests/Unit/Mutators/HexBinaryMutatorTest.php
+++ b/tests/Unit/Mutators/HexBinaryMutatorTest.php
@@ -44,6 +44,7 @@ class HexBinaryMutatorTest extends TestCase
             '5d87fca1c8f5c2ec21',
             'c334821e50532bd40227',
         ];
+
         return array_map(function ($hex) {
             return [$hex, hex2bin($hex)];
         }, $hexes);

--- a/tests/Unit/Mutators/HexBinaryMutatorTest.php
+++ b/tests/Unit/Mutators/HexBinaryMutatorTest.php
@@ -33,21 +33,23 @@ class HexBinaryMutatorTest extends TestCase
     public function hexProvider()
     {
         $hexes = [
-            'e7',
-            '232f',
-            '0b76e0',
-            '65c1b7b0',
-            'e2f9995c0b',
-            'cfc46177b9cd',
-            '01f4890a5996c1',
-            'd8d3a96d2a441b39',
-            '5d87fca1c8f5c2ec21',
-            'c334821e50532bd40227',
+            'Hex string of length 2' => 'e7',
+            'Hex string of length 4' => '232f',
+            'Hex string of length 6' => '0b76e0',
+            'Hex string of length 8' => '65c1b7b0',
+            'Hex string of length 10' => 'e2f9995c0b',
+            'Hex string of length 12' => 'cfc46177b9cd',
+            'Hex string of length 14' => '01f4890a5996c1',
+            'Hex string of length 16' => 'd8d3a96d2a441b39',
+            'Hex string of length 18' => '5d87fca1c8f5c2ec21',
+            'Hex string of length 20' => 'c334821e50532bd40227',
         ];
 
-        return array_map(function ($hex) {
-            return [$hex, hex2bin($hex)];
-        }, $hexes);
+        foreach ($hexes as $label => $hex) {
+            $hexes[$label] = [$hex, hex2bin($hex)];
+        }
+
+        return $hexes;
     }
 
     /**
@@ -66,13 +68,13 @@ class HexBinaryMutatorTest extends TestCase
     public function notHexProvider()
     {
         return [
-            [new stdClass], // Cannot serialize an object
-            [0], // Cannot serialize an int
-            [0.3], // Cannot serialize a float
-            ['YzMzNDgyMWU1MDUzMmJkNDAy'], // Can't serialize a string that contains non-hex digits
-            [null], // Null cannot pass
-            [true], // Bools also not ok as hex data
-            ['a'], // Length must be even for a hex string to be representing bytes
+            'An object cannot be serialized' => [new stdClass],
+            'An int cannot be serialized' => [0],
+            'Floats cannot be serialized' => [0.3],
+            'Only hex strings can be serialiazed' => ['YzMzNDgyMWU1MDUzMmJkNDAy'],
+            'Null cannot be serialized' => [null],
+            'Boolas cannot be serialized' => [true],
+            'Hex strings should have even lengths to be valid bytes representations' => ['a'],
          ];
     }
 }

--- a/tests/Unit/Mutators/HexBinaryMutatorTest.php
+++ b/tests/Unit/Mutators/HexBinaryMutatorTest.php
@@ -3,7 +3,7 @@
 namespace Weebly\Mutate\Mutators;
 
 use PHPUnit\Framework\TestCase;
-use \stdClass;
+use stdClass;
 
 class HexBinaryMutatorTest extends TestCase
 {
@@ -44,7 +44,7 @@ class HexBinaryMutatorTest extends TestCase
             '5d87fca1c8f5c2ec21',
             'c334821e50532bd40227',
         ];
-        return array_map(function($hex) {
+        return array_map(function ($hex) {
             return [$hex, hex2bin($hex)];
         }, $hexes);
     }

--- a/tests/Unit/Mutators/HexBinaryMutatorTest.php
+++ b/tests/Unit/Mutators/HexBinaryMutatorTest.php
@@ -33,21 +33,17 @@ class HexBinaryMutatorTest extends TestCase
     public function hexProvider()
     {
         $hexes = [
-            'Hex string of length 2' => 'e7',
-            'Hex string of length 4' => '232f',
-            'Hex string of length 6' => '0b76e0',
-            'Hex string of length 8' => '65c1b7b0',
-            'Hex string of length 10' => 'e2f9995c0b',
-            'Hex string of length 12' => 'cfc46177b9cd',
-            'Hex string of length 14' => '01f4890a5996c1',
-            'Hex string of length 16' => 'd8d3a96d2a441b39',
-            'Hex string of length 18' => '5d87fca1c8f5c2ec21',
-            'Hex string of length 20' => 'c334821e50532bd40227',
+            'Hex string of length 2' => ['e7', hex2bin('e7')],
+            'Hex string of length 4' => ['232f', hex2bin('232f')],
+            'Hex string of length 6' => ['0b76e0', hex2bin('0b76e0')],
+            'Hex string of length 8' => ['65c1b7b0', hex2bin('65c1b7b0')],
+            'Hex string of length 10' => ['e2f9995c0b', hex2bin('e2f9995c0b')],
+            'Hex string of length 12' => ['cfc46177b9cd', hex2bin('cfc46177b9cd')],
+            'Hex string of length 14' => ['01f4890a5996c1', hex2bin('01f4890a5996c1')],
+            'Hex string of length 16' => ['d8d3a96d2a441b39', hex2bin('d8d3a96d2a441b39')],
+            'Hex string of length 18' => ['5d87fca1c8f5c2ec21', hex2bin('5d87fca1c8f5c2ec21')],
+            'Hex string of length 20' => ['c334821e50532bd40227', hex2bin('c334821e50532bd40227')],
         ];
-
-        foreach ($hexes as $label => $hex) {
-            $hexes[$label] = [$hex, hex2bin($hex)];
-        }
 
         return $hexes;
     }
@@ -73,7 +69,7 @@ class HexBinaryMutatorTest extends TestCase
             'Floats cannot be serialized' => [0.3],
             'Only hex strings can be serialiazed' => ['YzMzNDgyMWU1MDUzMmJkNDAy'],
             'Null cannot be serialized' => [null],
-            'Boolas cannot be serialized' => [true],
+            'Booleans cannot be serialized' => [true],
             'Hex strings should have even lengths to be valid bytes representations' => ['a'],
          ];
     }

--- a/tests/Unit/Mutators/HexBinaryMutatorTest.php
+++ b/tests/Unit/Mutators/HexBinaryMutatorTest.php
@@ -3,7 +3,6 @@
 namespace Weebly\Mutate\Mutators;
 
 use PHPUnit\Framework\TestCase;
-use Weebly\Mutate\Exceptions\MutateException;
 
 class HexBinaryMutatorTest extends TestCase
 {
@@ -53,7 +52,7 @@ class HexBinaryMutatorTest extends TestCase
      */
     public function notHexProvider()
     {
-         return [
+        return [
             [new \stdClass],
             [0],
             [base64_encode(random_bytes(20))],

--- a/tests/Unit/Mutators/HexBinaryMutatorTest.php
+++ b/tests/Unit/Mutators/HexBinaryMutatorTest.php
@@ -3,6 +3,7 @@
 namespace Weebly\Mutate\Mutators;
 
 use PHPUnit\Framework\TestCase;
+use \stdClass;
 
 class HexBinaryMutatorTest extends TestCase
 {
@@ -31,10 +32,21 @@ class HexBinaryMutatorTest extends TestCase
      */
     public function hexProvider()
     {
-        for ($i = 0; $i < 10; $i++) {
-            $bytes = random_bytes(20);
-            yield [bin2hex($bytes), $bytes];
-        }
+        $hexes = [
+            'e7',
+            '232f',
+            '0b76e0',
+            '65c1b7b0',
+            'e2f9995c0b',
+            'cfc46177b9cd',
+            '01f4890a5996c1',
+            'd8d3a96d2a441b39',
+            '5d87fca1c8f5c2ec21',
+            'c334821e50532bd40227',
+        ];
+        return array_map(function($hex) {
+            return [$hex, hex2bin($hex)];
+        }, $hexes);
     }
 
     /**
@@ -53,11 +65,13 @@ class HexBinaryMutatorTest extends TestCase
     public function notHexProvider()
     {
         return [
-            [new \stdClass],
-            [0],
-            [base64_encode(random_bytes(20))],
-            [null],
-            [true],
+            [new stdClass], // Cannot serialize an object
+            [0], // Cannot serialize an int
+            [0.3], // Cannot serialize a float
+            ['YzMzNDgyMWU1MDUzMmJkNDAy'], // Can't serialize a string that contains non-hex digits
+            [null], // Null cannot pass
+            [true], // Bools also not ok as hex data
+            ['a'], // Length must be even for a hex string to be representing bytes
          ];
     }
 }

--- a/tests/Unit/Mutators/HexBinaryMutatorTest.php
+++ b/tests/Unit/Mutators/HexBinaryMutatorTest.php
@@ -2,8 +2,8 @@
 
 namespace Weebly\Mutate\Mutators;
 
-use PHPUnit\Framework\TestCase;
 use stdClass;
+use PHPUnit\Framework\TestCase;
 
 class HexBinaryMutatorTest extends TestCase
 {

--- a/tests/Unit/Mutators/HexBinaryMutatorTest.php
+++ b/tests/Unit/Mutators/HexBinaryMutatorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Weebly\Mutate\Mutators;
+
+use PHPUnit\Framework\TestCase;
+use Weebly\Mutate\Exceptions\MutateException;
+
+class HexBinaryMutatorTest extends TestCase
+{
+    /**
+     * @param string $hex
+     * @param string $expected
+     * @dataProvider hexProvider
+     */
+    public function testSerialize($hex, $expected)
+    {
+        $this->assertEquals($expected, (new HexBinaryMutator())->serializeAttribute($hex));
+    }
+
+    /**
+     * @param string $expected
+     * @param string $binary
+     * @dataProvider hexProvider
+     */
+    public function testUnserialize($expected, $binary)
+    {
+        $this->assertEquals($expected, (new HexBinaryMutator())->unserializeAttribute($binary));
+    }
+
+    /**
+     * @return \Iterator
+     */
+    public function hexProvider()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $bytes = random_bytes(20);
+            yield [bin2hex($bytes), $bytes];
+        }
+    }
+
+    /**
+     * @param mixed $value
+     * @dataProvider notHexProvider
+     * @expectedException \Weebly\Mutate\Exceptions\MutateException
+     */
+    public function testWrongFormat($value)
+    {
+        (new HexBinaryMutator())->serializeAttribute($value);
+    }
+
+    /**
+     * @return array
+     */
+    public function notHexProvider()
+    {
+         return [
+            [new \stdClass],
+            [0],
+            [base64_encode(random_bytes(20))],
+            [null],
+            [true],
+         ];
+    }
+}

--- a/tests/Unit/Mutators/UnixTimestampMutatorTest.php
+++ b/tests/Unit/Mutators/UnixTimestampMutatorTest.php
@@ -2,9 +2,8 @@
 
 namespace Weebly\Mutate\Mutators;
 
-use PHPUnit\Framework\TestCase;
-use Weebly\Mutate\Exceptions\MutateException;
 use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
 
 class UnixTimestampMutatorTest extends TestCase
 {

--- a/tests/Unit/Mutators/UnixTimestampMutatorTest.php
+++ b/tests/Unit/Mutators/UnixTimestampMutatorTest.php
@@ -38,11 +38,13 @@ class UnixTimestampMutatorTest extends TestCase
      */
     public function carbonProvider()
     {
-        yield [Carbon::now(), time()];
-        for ($i = 0; $i < 10; $i++) {
-            $t = rand(1, time());
-            $c = Carbon::createFromTimestamp($t);
-            yield [$c, $t];
-        }
+        $now = time();
+        return [
+            [Carbon::createFromTimestamp($now), $now],
+            [Carbon::createFromTimestamp(1), 1],
+            [Carbon::createFromTimestamp(pow(2, 32) - 1), pow(2, 32) - 1],
+            [Carbon::createFromTimestamp(-200), -200],
+            [Carbon::createFromTimestamp(0), 0],
+        ];
     }
 }

--- a/tests/Unit/Mutators/UnixTimestampMutatorTest.php
+++ b/tests/Unit/Mutators/UnixTimestampMutatorTest.php
@@ -39,6 +39,7 @@ class UnixTimestampMutatorTest extends TestCase
     public function carbonProvider()
     {
         $now = time();
+
         return [
             [Carbon::createFromTimestamp($now), $now],
             [Carbon::createFromTimestamp(1), 1],

--- a/tests/Unit/Mutators/UnixTimestampMutatorTest.php
+++ b/tests/Unit/Mutators/UnixTimestampMutatorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Weebly\Mutate\Mutators;
+
+use PHPUnit\Framework\TestCase;
+use Weebly\Mutate\Exceptions\MutateException;
+use Carbon\Carbon;
+
+class UnixTimestampMutatorTest extends TestCase
+{
+    /**
+     * @param string $carbon
+     * @param string $expected
+     * @dataProvider carbonProvider
+     */
+    public function testSerialize($carbon, $expected)
+    {
+        $this->assertEquals($expected, (new UnixTimestampMutator())->serializeAttribute($carbon));
+    }
+
+    /**
+     * @param string $expected
+     * @param string $binary
+     * @dataProvider carbonProvider
+     */
+    public function testUnserialize($expected, $timestamp)
+    {
+        $unserialized = (new UnixTimestampMutator())->unserializeAttribute($timestamp);
+        $this->assertEquals($expected->year, $unserialized->year);
+        $this->assertEquals($expected->month, $unserialized->month);
+        $this->assertEquals($expected->day, $unserialized->day);
+        $this->assertEquals($expected->hour, $unserialized->hour);
+        $this->assertEquals($expected->minute, $unserialized->minute);
+        $this->assertEquals($expected->second, $unserialized->second);
+    }
+
+    /**
+     * @return \Iterator
+     */
+    public function carbonProvider()
+    {
+        yield [Carbon::now(), time()];
+        for ($i = 0; $i < 10; $i++) {
+            $t = rand(1, time());
+            $c = Carbon::createFromTimestamp($t);
+            yield [$c, $t];
+        }
+    }
+}

--- a/tests/Unit/Mutators/UnixTimestampMutatorTest.php
+++ b/tests/Unit/Mutators/UnixTimestampMutatorTest.php
@@ -41,11 +41,11 @@ class UnixTimestampMutatorTest extends TestCase
         $now = time();
 
         return [
-            [Carbon::createFromTimestamp($now), $now],
-            [Carbon::createFromTimestamp(1), 1],
-            [Carbon::createFromTimestamp(pow(2, 32) - 1), pow(2, 32) - 1],
-            [Carbon::createFromTimestamp(-200), -200],
-            [Carbon::createFromTimestamp(0), 0],
+            'Now' => [Carbon::createFromTimestamp($now), $now],
+            'Timestamp 1' => [Carbon::createFromTimestamp(1), 1],
+            'Timestamp for max uint32' => [Carbon::createFromTimestamp(pow(2, 32) - 1), pow(2, 32) - 1],
+            'Negative timestamp' => [Carbon::createFromTimestamp(-200), -200],
+            'Timestamp 0' => [Carbon::createFromTimestamp(0), 0],
         ];
     }
 }


### PR DESCRIPTION
Adds 2 additional mutators:

- `HexBinaryMutator` which presents an attribute as a hex string but stores it as binary data
- `UnixTimestampMutator` which presents an attribute as a Carbon dateobject but stores it as an int