### PR TITLE
Allow mutators to accept attribute names

### DIFF
--- a/src/Mutators/HexBinaryMutator.php
+++ b/src/Mutators/HexBinaryMutator.php
@@ -13,10 +13,12 @@ class HexBinaryMutator implements MutatorContract
     /**
      * {@inheritdoc}
      */
-    public function serializeAttribute($value)
+    public function serializeAttribute($value, $attribute = null)
     {
         if (! ctype_xdigit($value) || strlen($value) % 2 !== 0) {
-            throw new MutateException(__METHOD__.' expects the value to be serialized to be a hexadecimal string.');
+            $valueString = print_r($value,true);
+            $attributeString = $attribute ? 'of '.$attribute.' ' : '';
+            throw new MutateException(__METHOD__.' expects the value '.$attributeString.'('.$valueString.') to be serialized to be a hexadecimal string.');
         }
 
         return hex2bin($value);
@@ -25,7 +27,7 @@ class HexBinaryMutator implements MutatorContract
     /**
      * {@inheritdoc}
      */
-    public function unserializeAttribute($value)
+    public function unserializeAttribute($value, $attribute = null)
     {
         if (! $value) {
             return;


### PR DESCRIPTION
**This is a work in progress, but I wanted to put it up to get discussion before I rabbit-holed!**

I wanted to get a better error message when the hex mutator fails, and it looks like there's no reason the hasMutator trait couldn't pass attributes to the mutators in this case, so I gave it a shot.

Implementation has to use reflection, because I didn't want to break existing mutators. I could potentially cache the reflection lookup if we're worried about performance. I'm not sure what its performance characteristics are.

Before:

<img width="586" alt="before" src="https://user-images.githubusercontent.com/32340827/30931478-a1af31f4-a379-11e7-83ae-ed0d847b78cb.png">

After:

<img width="588" alt="after mutator does not accept attribute" src="https://user-images.githubusercontent.com/32340827/30931486-a853734e-a379-11e7-997d-48c2d7bacfe5.png">

After when mutator accepts attribute parameter:

<img width="589" alt="after mutator accepts attribute" src="https://user-images.githubusercontent.com/32340827/30931502-b3914948-a379-11e7-8138-ef34adea7ad3.png">
