### PR TITLE
Fix failing wherein

### DIFF
--- a/src/Database/EloquentBuilder.php
+++ b/src/Database/EloquentBuilder.php
@@ -87,11 +87,11 @@ class EloquentBuilder extends Builder
         // Add where statement back
         $this->query->wheres[] = $where;
 
-        // Loop over all the mutated values and add the bindings
+        // Reset the bindings to the previous value
         $this->query->bindings = $bindings;
+        // Loop over all the mutated values and add the bindings
         foreach ($mutatedValues as $value) {
             if (! $value instanceof Expression) {
-                // Reset the bindings to the previous value
 
                 // Add the mutated bindings back
                 $this->addBinding($value, 'where');

--- a/src/Database/EloquentBuilder.php
+++ b/src/Database/EloquentBuilder.php
@@ -88,10 +88,10 @@ class EloquentBuilder extends Builder
         $this->query->wheres[] = $where;
 
         // Loop over all the mutated values and add the bindings
+        $this->query->bindings = $bindings;
         foreach ($mutatedValues as $value) {
             if (! $value instanceof Expression) {
                 // Reset the bindings to the previous value
-                $this->query->bindings = $bindings;
 
                 // Add the mutated bindings back
                 $this->addBinding($value, 'where');

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -88,9 +88,11 @@ class MutatorTest extends TestCase
     public function test_where_in()
     {
         $id = Uuid::uuid1()->toString();
+        $id2 = Uuid::uuid1()->toString();
         $model = (new TestModel())->create(['id' => $id, 'name' => 'A chair']);
-        $p = $model->whereIn('id', [$id])->first();
-        $this->assertEquals($id, $p->id);
+        $model2 = (new TestModel())->create(['id' => $id2, 'name' => 'A table']);
+        $p = $model->whereIn('id', [$id])->get();
+        $this->assertEquals(2, $p->count());
     }
 
     public function test_update()

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -85,13 +85,18 @@ class MutatorTest extends TestCase
         $this->assertEquals($id, $p->id);
     }
 
+    /**
+     * @group debug
+     *
+     * @return void
+     */
     public function test_where_in()
     {
         $id = Uuid::uuid1()->toString();
         $id2 = Uuid::uuid1()->toString();
         $model = (new TestModel())->create(['id' => $id, 'name' => 'A chair']);
         $model2 = (new TestModel())->create(['id' => $id2, 'name' => 'A table']);
-        $p = $model->whereIn('id', [$id])->get();
+        $p = $model->whereIn('id', [$id, $id2])->get();
         $this->assertEquals(2, $p->count());
     }
 


### PR DESCRIPTION
Prevents the bindings from being constantly reset which prevented adding the correct bindings in the case of a `whereIn` query.

Fixes cases where `whereIn` only returns a single record where there should be many. Fixes throwing exceptions for mismatched binding numbers too.