### PR TITLE
Pivot mutators

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -10,7 +10,7 @@ abstract class Model extends Eloquent
     use HasMutators;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getKey()
     {

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -10,6 +10,14 @@ abstract class Model extends Eloquent
     use HasMutators;
 
     /**
+     * @inheritdoc
+     */
+    public function getKey()
+    {
+        return $this->getAttributeFromArray($this->getKeyName());
+    }
+
+    /**
      * @param string $key
      * @return \Illuminate\Foundation\Application|mixed
      */

--- a/tests/Integration/PivotMutatorTest.php
+++ b/tests/Integration/PivotMutatorTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Weebly\Mutate;
+
+use DB;
+use Ramsey\Uuid\Uuid;
+use Orchestra\Testbench\TestCase;
+use Weebly\Mutate\Database\Model;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @group integration
+ */
+class PivotMutatorTest extends TestCase
+{
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.key', 'base64:+oDiXVEBRapl1N6RWgVx/xdzJ4aXgSAsD6QbAYmNE8A=');
+        $app['config']->set('app.cipher', 'AES-256-CBC');
+        $app['config']->set('app.debug', 'true');
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app->singleton('mutator', function (Application $app) {
+            $mutator = new MutatorProvider();
+            $default_mutators = (require realpath(__DIR__.'/../../config/config.php'))['enabled'];
+
+            $mutator->registerMutators($default_mutators);
+
+            return $mutator;
+        });
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('test_model_a', function ($table) {
+            $table->string('name');
+        });
+        DB::connection()->getPdo()->exec('ALTER TABLE test_model_a ADD id BINARY(16);');
+
+        Schema::create('test_model_b', function ($table) {
+            $table->string('name');
+        });
+        DB::connection()->getPdo()->exec('ALTER TABLE test_model_b ADD id BINARY(16);');
+
+        Schema::create('pivot_table', function ($table) {
+            $table->string('extra')->nullable();
+        });
+        DB::connection()->getPdo()->exec('ALTER TABLE pivot_table ADD a_id BINARY(16);');
+        DB::connection()->getPdo()->exec('ALTER TABLE pivot_table ADD b_id BINARY(16);');
+    }
+
+    public function testPivotRecordsGetCreated()
+    {
+        $idA = Uuid::uuid1()->toString();
+        $idB = Uuid::uuid1()->toString();
+        $modelA = (new TestModelA())->create(['id' => $idA, 'name' => 'A table']);
+        $modelB = (new TestModelB())->create(['id' => $idB, 'name' => 'B table']);
+        
+        $modelA->testModelBs()->attach($modelB, ['extra' => 'Something Extra']);
+
+        $this->assertEquals(1, $modelA->testModelBs()->count());
+    }
+}
+
+class TestModelA extends Model
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $table = 'test_model_a';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $guarded = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public $timestamps = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public $incrementing = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $keyType = 'string';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $mutate = [
+        'id' => 'uuid_v1_binary',
+    ];
+
+    public function testModelBs()
+    {
+        return $this->belongsToMany(TestModelB::class, 'pivot_table', 'a_id', 'b_id')->withPivot('extra');
+    }
+}
+
+class TestModelB extends Model
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $table = 'test_model_a';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $guarded = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public $timestamps = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public $incrementing = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $keyType = 'string';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $mutate = [
+        'id' => 'uuid_v1_binary',
+    ];
+
+    public function testModelAs()
+    {
+        return $this->belongsToMany(TestModelA::class, 'pivot_table', 'b_id', 'a_id')->withPivot('extra');
+    }
+}
+

--- a/tests/Integration/PivotMutatorTest.php
+++ b/tests/Integration/PivotMutatorTest.php
@@ -66,7 +66,7 @@ class PivotMutatorTest extends TestCase
         $idB = Uuid::uuid1()->toString();
         $modelA = (new TestModelA())->create(['id' => $idA, 'name' => 'A table']);
         $modelB = (new TestModelB())->create(['id' => $idB, 'name' => 'B table']);
-        
+
         $modelA->testModelBs()->attach($modelB, ['extra' => 'Something Extra']);
 
         $this->assertEquals(1, $modelA->testModelBs()->count());
@@ -152,4 +152,3 @@ class TestModelB extends Model
         return $this->belongsToMany(TestModelA::class, 'pivot_table', 'b_id', 'a_id')->withPivot('extra');
     }
 }
-


### PR DESCRIPTION
@khepin I couldnt add you as a reviewer for some reason.

Check this out. So currently if you have a ManyToMany you cannot use attach models to each other because it tries to use the formatted (hex) version of the uuid. This fix is not the most ideal one, but its better than going down the rabbit hole of overriding `belongsToMany` to then override the necessary methods to deal with formatting. This fix works by overriding `getKey` which is used in eloquent relationship code to return the unformatted (binary) version of the id, which enables the relationship code to actually succeed. 