### PR TITLE
Add whereKey to extend on Eloquent Builder

### DIFF
--- a/src/Database/EloquentBuilder.php
+++ b/src/Database/EloquentBuilder.php
@@ -67,8 +67,10 @@ class EloquentBuilder extends Builder
     {
         if (is_array($id) || $id instanceof Arrayable) {
             $this->whereIn($this->model->getQualifiedKeyName(), $id);
+
             return $this;
         }
+
         return parent::whereKey($id);
     }
 

--- a/src/Database/EloquentBuilder.php
+++ b/src/Database/EloquentBuilder.php
@@ -63,6 +63,18 @@ class EloquentBuilder extends Builder
     /**
      * {@inheritdoc}
      */
+    public function whereKey($id)
+    {
+        if (is_array($id) || $id instanceof Arrayable) {
+            $this->whereIn($this->model->getQualifiedKeyName(), $id);
+            return $this;
+        }
+        return parent::whereKey($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function whereIn($column, $values, $boolean = 'and', $not = false)
     {
         $bindings = $this->query->bindings;

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -88,6 +88,18 @@ class MutatorTest extends TestCase
         $this->assertEquals($id, $p->id);
     }
 
+    public function test_array_of_find()
+    {
+        $id = Uuid::uuid1()->toString();
+        $model = (new TestModel())->create(['id' => $id, 'name' => 'Name A']);
+        $id2 = Uuid::uuid1()->toString();
+        $model = (new TestModel())->create(['id' => $id2, 'name' => 'Name B']);
+        $p = $model->find([$id, $id2]);
+        $this->assertEquals(2, $p->count());
+        $this->assertEquals($id, $p[0]->id);
+        $this->assertEquals($id2, $p[1]->id);
+    }
+
     public function test_non_mutated_columns()
     {
         $id = Uuid::uuid1()->toString();
@@ -109,6 +121,18 @@ class MutatorTest extends TestCase
         $model2 = (new TestModel())->create(['id' => $id2, 'name' => 'A table']);
         $p = $model->whereIn('id', [$id, $id2])->get();
         $this->assertEquals(2, $p->count());
+    }
+
+    public function test_where_key()
+    {
+        $id = Uuid::uuid1()->toString();
+        $id2 = Uuid::uuid1()->toString();
+        $model = (new TestModel())->create(['id' => $id, 'name' => 'A chair']);
+        $model2 = (new TestModel())->create(['id' => $id2, 'name' => 'A table']);
+        $p = $model->whereKey([$id, $id2])->get();
+        $this->assertEquals(2, $p->count());
+        $this->assertEquals($id, $p[0]->id);
+        $this->assertEquals($id2, $p[1]->id);
     }
 
     public function test_update()


### PR DESCRIPTION
Addresses Issue #16

After:
```
php artisan tinker

>>> Site::find('someuuid1');
=> App\Models\Eloquent\Site {#825
     id: b"ùUêØ:\x05G█ø*═ùª\vo¶",
   }

>>> Site::find(['someuuid1']);
[!] Aliasing 'Site' to 'App\Models\Eloquent\Site' for this Tinker session.
=> Illuminate\Database\Eloquent\Collection {#826
     all: [
       App\Models\Eloquent\Site {#827
         id: b"ùUêØ:\x05G█ø*═ùª\vo¶",
       },
     ],
   }
``` 