### PR TITLE
Better fix for double serialize

### DIFF
--- a/src/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Database/Eloquent/Relations/BelongsToMany.php
@@ -4,15 +4,14 @@ namespace Weebly\Mutate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
-use Weebly\Mutate\Exceptions\MutateException;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 
 class BelongsToMany extends EloquentBelongsToMany
 {
     /**
-     * Local cache of mutated attributes
-     * 
+     * Local cache of mutated attributes.
+     *
      * @var array
      */
     protected $mutated_values = [];
@@ -166,6 +165,7 @@ class BelongsToMany extends EloquentBelongsToMany
 
                 $value = $related->serializeAttribute($related->getKeyName(), $attribute);
                 $this->mutated_values[] = $value;
+
                 return $value;
             }, $values);
         }


### PR DESCRIPTION
@elliotfehr I released a PR the other day, catching MutateException in parseIds because eloquent can call it multiple times. Sometimes a mutate exception isn't thrown because the already been mutated id can be rebuilt into a uuid, not triggering that exception. This is why the issue I was discussing with you is only happening occasionally. This instead just keeps a local cache of the attributes that its already mutated, checks that cache before attempting mutation. Kinda gross, but fixes our issue and we can move forward. 