### PR TITLE
Only attempt to serialize the attribute if it is not null.

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -28,7 +28,7 @@ abstract class Model extends Eloquent
      */
     public function setAttribute($key, $value)
     {
-        if ($this->hasMutator($key) && !is_null($value)) {
+        if ($this->hasMutator($key) && ! is_null($value)) {
             // Set the serialized value on the parent attributes
             $this->attributes[$key] = $this->serializeAttribute($key, $value);
 

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -28,7 +28,7 @@ abstract class Model extends Eloquent
      */
     public function setAttribute($key, $value)
     {
-        if ($this->hasMutator($key)) {
+        if ($this->hasMutator($key) && !is_null($value)) {
             // Set the serialized value on the parent attributes
             $this->attributes[$key] = $this->serializeAttribute($key, $value);
 


### PR DESCRIPTION
This will allow setting nullable columns back to null rather than throwing an exception when null is attempted to be serialized.