### PR TITLE
update for laravel 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/php:7.1.8-browsers
+      - image: circleci/php:7.2-browsers
       - image: circleci/mysql:5.7
         environment:
           - MYSQL_USER=mutate

--- a/composer.json
+++ b/composer.json
@@ -6,15 +6,15 @@
     "keywords": ["laravel", "eloquent", "uuid", "encrypt", "database"],
     "require": {
         "ramsey/uuid": "~3.0",
-        "illuminate/database": "~5.0",
-        "illuminate/support": "~5.0",
-        "illuminate/encryption": "~5.0"
+        "illuminate/database": "~6.0",
+        "illuminate/support": "~6.0",
+        "illuminate/encryption": "~6.0"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.9",
-        "phpunit/phpunit": "^6.3",
-        "laravel/framework": "5.5.*",
-        "orchestra/testbench": "~3.0"
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^8.0",
+        "laravel/framework": "6.*",
+        "orchestra/testbench": "~4.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Integration/BelongsToManyMutatedTest.php
+++ b/tests/Integration/BelongsToManyMutatedTest.php
@@ -49,7 +49,7 @@ class BelongsToManyMutatedTest extends TestCase
         });
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         DB::connection()->getPdo()->exec('DROP TABLE IF EXISTS test_model_a');

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -39,7 +39,7 @@ class MutatorTest extends TestCase
         });
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Mutators/HexBinaryMutatorTest.php
+++ b/tests/Unit/Mutators/HexBinaryMutatorTest.php
@@ -51,10 +51,10 @@ class HexBinaryMutatorTest extends TestCase
     /**
      * @param mixed $value
      * @dataProvider notHexProvider
-     * @expectedException \Weebly\Mutate\Exceptions\MutateException
      */
     public function testWrongFormat($value)
     {
+        $this->expectException(\Weebly\Mutate\Exceptions\MutateException::class);
         (new HexBinaryMutator())->serializeAttribute($value);
     }
 


### PR DESCRIPTION
this allows for use with laravel 6. `orchestra/testbench` does not have compatibility between laravel 5 and 6, so can't make this backwards compatible without significant changes unfortunately