### PR TITLE
Add flag to by-pass cache

### DIFF
--- a/src/Database/EloquentBuilder.php
+++ b/src/Database/EloquentBuilder.php
@@ -2,9 +2,9 @@
 
 namespace Weebly\Mutate\Database;
 
-use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Str;
 
 class EloquentBuilder extends Builder
 {

--- a/src/Database/EloquentBuilder.php
+++ b/src/Database/EloquentBuilder.php
@@ -162,7 +162,7 @@ class EloquentBuilder extends Builder
         $model = $this->model;
         if (is_null($key)) {
             $mutatedValues = $values->map(function ($v) use ($model, $mutatedColumn) {
-                return $model->unserializeAttribute($mutatedColumn, $v);
+                return $model->unserializeAttribute($mutatedColumn, $v, true);
             });
         } else {
             $mutatedValues = $values->mapWithKeys(function ($v, $k) use ($model, $mutatedColumn, $key) {

--- a/src/Database/EloquentBuilder.php
+++ b/src/Database/EloquentBuilder.php
@@ -166,7 +166,7 @@ class EloquentBuilder extends Builder
             });
         } else {
             $mutatedValues = $values->mapWithKeys(function ($v, $k) use ($model, $mutatedColumn, $key) {
-                return [$model->unserializeAttribute($key, $k) => $model->unserializeAttribute($mutatedColumn, $v)];
+                return [$model->unserializeAttribute($key, $k, true) => $model->unserializeAttribute($mutatedColumn, $v, true)];
             });
         }
 

--- a/src/Database/Traits/HasMutators.php
+++ b/src/Database/Traits/HasMutators.php
@@ -41,13 +41,14 @@ trait HasMutators
     /**
      * @param string $attribute
      * @param mixed  $value
+     * @param boolean $force
      * @return mixed
      */
-    public function unserializeAttribute($attribute, $value)
+    public function unserializeAttribute($attribute, $value, $force = false)
     {
         // Mutate the attribute if a mutator is defined
         if ($this->hasMutator($attribute)) {
-            if (array_key_exists($attribute, $this->mutatedCache)) {
+            if ($force === false && array_key_exists($attribute, $this->mutatedCache)) {
                 return $this->mutatedCache[$attribute];
             }
 

--- a/src/Database/Traits/HasMutators.php
+++ b/src/Database/Traits/HasMutators.php
@@ -41,7 +41,7 @@ trait HasMutators
     /**
      * @param string $attribute
      * @param mixed  $value
-     * @param boolean $force
+     * @param bool $force
      * @return mixed
      */
     public function unserializeAttribute($attribute, $value, $force = false)

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -167,10 +167,16 @@ class MutatorTest extends TestCase
     public function test_pluck_with_key()
     {
         $id = Uuid::uuid1()->toString();
-        $location = 'Foo';
-        (new TestModel())->create(['id' => $id, 'name' => 'A chair', 'location' => $location])->save();
-        $ids = TestModel::where('id', $id)->pluck('id', 'location')->toArray();
-        $this->assertEquals([$location => $id], $ids);
+        $id2 = Uuid::uuid1()->toString();
+        (new TestModel())->create(['id' => $id, 'name' => 'A chair', 'location' => 'Foo'])->save();
+        (new TestModel())->create(['id' => $id2, 'name' => 'A chair', 'location' => 'Bar'])->save();
+        $ids = TestModel::whereIn('id', [$id, $id2])->pluck('id', 'location')->toArray();
+
+        $expected = [
+            'Foo' => $id,
+            'Bar' => $id2,
+        ];
+       $this->assertEquals($expected, $ids);
     }
 
     public function test_timestamps()

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -3,11 +3,11 @@
 namespace Weebly\Mutate;
 
 use DB;
-use Ramsey\Uuid\Uuid;
-use Orchestra\Testbench\TestCase;
-use Weebly\Mutate\Database\Model;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+use Ramsey\Uuid\Uuid;
+use Weebly\Mutate\Database\Model;
 
 /**
  * @group integration
@@ -157,7 +157,7 @@ class MutatorTest extends TestCase
     public function test_pluck()
     {
         $id = Uuid::uuid1()->toString();
-        $id2 = Uuid::uuid1()->toString();;
+        $id2 = Uuid::uuid1()->toString();
         (new TestModel())->create(['id' => $id, 'name' => 'A chair', 'location' => 'Foo'])->save();
         (new TestModel())->create(['id' => $id2, 'name' => 'A chair', 'location' => 'Foo'])->save();
         $ids = TestModel::whereIn('id', [$id, $id2])->pluck('id')->toArray();
@@ -176,7 +176,7 @@ class MutatorTest extends TestCase
             'Foo' => $id,
             'Bar' => $id2,
         ];
-       $this->assertEquals($expected, $ids);
+        $this->assertEquals($expected, $ids);
     }
 
     public function test_timestamps()

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -157,9 +157,11 @@ class MutatorTest extends TestCase
     public function test_pluck()
     {
         $id = Uuid::uuid1()->toString();
+        $id2 = Uuid::uuid1()->toString();;
         (new TestModel())->create(['id' => $id, 'name' => 'A chair', 'location' => 'Foo'])->save();
-        $ids = TestModel::where('id', $id)->pluck('id')->toArray();
-        $this->assertEquals([$id], $ids);
+        (new TestModel())->create(['id' => $id2, 'name' => 'A chair', 'location' => 'Foo'])->save();
+        $ids = TestModel::whereIn('id', [$id, $id2])->pluck('id')->toArray();
+        $this->assertEquals([$id, $id2], $ids);
     }
 
     public function test_pluck_with_key()


### PR DESCRIPTION
[We are re-using the same instance to unserialize](https://github.com/Weebly/laravel-mutate/blob/master/src/Database/EloquentBuilder.php#L162-L171), this is no good when "plucking" -- you end up getting the first model value for all models. I was thinking about cloning the model, but this seems cheaper.