### PR TITLE
Fix whereIn subquery for Laravel 5.8+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /.idea
 composer.lock
+.phpunit.result.cache

--- a/src/Database/EloquentBuilder.php
+++ b/src/Database/EloquentBuilder.php
@@ -3,13 +3,12 @@
 namespace Weebly\Mutate\Database;
 
 use Closure;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Builder as BaseEloquentBuilder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
 
-class EloquentBuilder extends Builder
+class EloquentBuilder extends BaseEloquentBuilder
 {
     /**
      * @var \Weebly\Mutate\Database\Model

--- a/src/Database/EloquentBuilder.php
+++ b/src/Database/EloquentBuilder.php
@@ -2,7 +2,10 @@
 
 namespace Weebly\Mutate\Database;
 
+use Closure;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder as BaseEloquentBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
 
@@ -83,6 +86,13 @@ class EloquentBuilder extends Builder
 
         parent::whereIn($column, $values, $boolean, $not);
 
+        // For sub-queries in Laravel 6. We don't need to do anything.
+        if ($values instanceof QueryBuilder ||
+            $values instanceof BaseEloquentBuilder ||
+            $values instanceof Closure) {
+            return $this;
+        }
+
         // Remove the last item of the array
         $where = array_pop($this->query->wheres);
 
@@ -96,7 +106,7 @@ class EloquentBuilder extends Builder
         if ($where['type'] === 'InSub' || $where['type'] === 'NotInSub') {
             $this->query->wheres[] = $where;
 
-            return parent::whereIn($column, $values, $boolean, $not);
+            return $this;
         }
 
         // Get the column name

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -132,6 +132,23 @@ class MutatorTest extends TestCase
         $this->assertEquals($id2, $p->last()->id);
     }
 
+    public function test_where_in_subquery_with_bindings()
+    {
+        $id = Uuid::uuid1()->toString();
+        $id2 = Uuid::uuid1()->toString();
+        $id3 = Uuid::uuid1()->toString();
+        (new TestModel())->create(['id' => $id, 'name' => 'A chair', 'location' => 'One']);
+        (new TestModel())->create(['id' => $id2, 'name' => 'A table', 'location' => 'Two']);
+
+        $query = TestModel::query()->where('name', '!=', 'A lamp')->whereIn('id', function ($query) {
+            $query->select('id')->from('test_model')->where('name', 'A lamp')->orWhere('name', 'A chair');
+        });
+
+        $p = $query->get();
+        $this->assertEquals(1, $p->count());
+        $this->assertEquals($id, $p->first()->id);
+    }
+
     public function test_where_in_wherein_subquery()
     {
         $id = Uuid::uuid1()->toString();

--- a/tests/Integration/MutatorTest.php
+++ b/tests/Integration/MutatorTest.php
@@ -136,7 +136,6 @@ class MutatorTest extends TestCase
     {
         $id = Uuid::uuid1()->toString();
         $id2 = Uuid::uuid1()->toString();
-        $id3 = Uuid::uuid1()->toString();
         (new TestModel())->create(['id' => $id, 'name' => 'A chair', 'location' => 'One']);
         (new TestModel())->create(['id' => $id2, 'name' => 'A table', 'location' => 'Two']);
 


### PR DESCRIPTION
The way Laravel handles subqueries in the `whereIn()` method has changed in Laravel 5.8. ([before](https://github.com/laravel/framework/blob/5.6/src/Illuminate/Database/Query/Builder.php#L823), [after](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Database/Query/Builder.php#L841)). When using this library, any query bindings in the subquery within a `whereIn` clause were discarded, resulting in SQL errors.

For example:
```php
// Terrible example query but hopefully, it gets the point across.
$query = Product::query()->where('type', 'physical')->whereIn('id', function ($sub) {
    $sub->select('product_id')->from('orders')->where('total', '>',  25.00);
});


dd($query->toSql(), $query->getBindings());

// Before this fix, in Laravel 5.8+
// select * from "products" where "type" = ? and "id" in (select "product_id" from "orders" where "total" > ?)
// [0 => 'physical']

// After this fix, in Laravel 5.8+
// [0 => 'physical', 1 => 25.00]
```

Before, when a query with a `whereIn` clause with a subquery was performed, the `$where['type']` would be set to [`InSub` or `NotInSub` depending on the operator](https://github.com/laravel/framework/blob/5ceadf91f13be89a3338c3d4166a4676272a23bf/src/Illuminate/Database/Query/Builder.php#L914-L928), in which case our custom `whereIn` method would basically do nothing and return early. 

https://github.com/Weebly/laravel-mutate/blob/b96b86056b1f2a5c6b1bdd034f65ef413203858b/src/Database/EloquentBuilder.php#L96-L100

> Sidenote: we shouldn't be calling `parent::whereIn()` again here since we've already called it in the lines above. This has also been corrected in this PR.

Now, with [the changes in Laravel 5.8+](https://github.com/laravel/framework/blob/78eb4dabcc03e189620c16f436358d41d31ae11f/src/Illuminate/Database/Query/Builder.php#L848-L856), the check we were performing no longer applies. The `$where['type']` is always either `In` or `NotIn`. Instead of checking the value of `$where['type']`, we can just check to see if it's "queryable" using the same logic that the `Illuminate\Database\Query\Builder` class uses, and return early like before.