### PR TITLE
[Laravel 6] Make newPivotQuery() method public to match parent.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "keywords": ["laravel", "eloquent", "uuid", "encrypt", "database"],
     "require": {
         "ramsey/uuid": "~3.0",
-        "illuminate/database": ">=5.0 <7.0.0",
-        "illuminate/support": ">=5.0 <7.0.0",
-        "illuminate/encryption": ">=5.0 <7.0.0"
+        "illuminate/database": "^6.0",
+        "illuminate/support": "^6.0",
+        "illuminate/encryption": "^6.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Database/Eloquent/Relations/BelongsToMany.php
@@ -119,7 +119,7 @@ class BelongsToMany extends EloquentBelongsToMany
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function newPivotQuery()
+    public function newPivotQuery()
     {
         $query = $this->newPivotStatement();
 


### PR DESCRIPTION
The method signature of `newPivotQuery()` was changed in Laravel 6. https://github.com/laravel/framework/pull/31677

This fixes the failing test suite [here](https://app.circleci.com/pipelines/github/Weebly/laravel-mutate/2/workflows/db680332-13ae-421b-8f72-0739979aec67/jobs/116/parallel-runs/0/steps/0-108)
