### PR TITLE
Override new Model function getKeyForSelectQuery

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -114,4 +114,12 @@ abstract class Model extends Eloquent
     {
         return $this->getAttribute($this->getKeyName());
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getKeyForSelectQuery()
+    {
+        return $this->getAttribute($this->getKeyName());
+    }
 }


### PR DESCRIPTION
Laravel 8 changes the way `Model::fresh()` and `refresh()` work. It now works similarly to `Model::save()` which ultimatley tries to access `the->original[]` attributes. This breaks the mutators since something like the `Model->id`, which uses a hex_binary mutator, will already be binary when trying to setAttribute instead of being hex. This throws an exception. 

We already override the `getKeyForSaveQuery()` which acts identical to `getKeyForSelectQuery()`.

Laravel 7.x Model::fresh() 
https://github.com/laravel/framework/blob/88dd075b9f1beaff93796a0ee51818796ca04654/src/Illuminate/Database/Eloquent/Model.php#L1214
Laravel 8.x Model::fresh()
https://github.com/laravel/framework/blob/d3ff07dbb343b7aaaef2cc623cc32516d8551a68/src/Illuminate/Database/Eloquent/Model.php#L1524

Laravel 7.x Model::getKeyForSaveQuery()
https://github.com/laravel/framework/blob/88dd075b9f1beaff93796a0ee51818796ca04654/src/Illuminate/Database/Eloquent/Model.php#L836
Laravel 8.x Model::getKeyForSelectQuery()
https://github.com/laravel/framework/blob/d3ff07dbb343b7aaaef2cc623cc32516d8551a68/src/Illuminate/Database/Eloquent/Model.php#L1100