### PR TITLE
Clear `mutateCache` on refresh

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -104,7 +104,7 @@ abstract class Model extends Eloquent
      */
     public function refresh()
     {
-        $this->mutatedCache = [];
+        $this->clearMutatorCache();
 
         return parent::refresh();
     }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -102,6 +102,16 @@ abstract class Model extends Eloquent
     /**
      * {@inheritdoc}
      */
+    public function refresh()
+    {
+        $this->mutatedCache = [];
+
+        return parent::refresh();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function newEloquentBuilder($query)
     {
         return new EloquentBuilder($query);

--- a/src/Database/Traits/HasMutators.php
+++ b/src/Database/Traits/HasMutators.php
@@ -91,4 +91,12 @@ trait HasMutators
     {
         return array_key_exists($attribute, $this->mutate);
     }
+
+    /**
+     * @return void
+     */
+    protected function clearMutatorCache()
+    {
+        $this->mutatedCache = [];
+    }
 }


### PR DESCRIPTION
### Problem
Using [`$model->refresh()`](https://laravel.com/docs/10.x/eloquent#refreshing-models) does not clear the cache

### Changes
* Clear the cache when using `->refresh()`