### PR TITLE
Properly unserialize `getOriginal` values

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -55,6 +55,30 @@ abstract class Model extends Eloquent
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getOriginal($key = null, $default = null)
+    {
+        $original = parent::getOriginal($key, $default);
+
+        if ($key) {
+            if ($this->hasMutator($key)) {
+                return $this->unserializeAttribute($key, $original);
+            }
+
+            return $original;
+        }
+
+        foreach ($original as $attribute => $value) {
+            if ($this->hasMutator($attribute)) {
+                $original[$attribute] = $this->unserializeAttribute($attribute, $value);
+            }
+        }
+
+        return $original;
+    }
+
+    /**
      * Define a many-to-many relationship.
      *
      * @param  string  $related

--- a/tests/Unit/Database/Traits/HasMutatorsTest.php
+++ b/tests/Unit/Database/Traits/HasMutatorsTest.php
@@ -52,6 +52,49 @@ class HasMutatorsTest extends TestCase
         $this->assertEquals('serialized_attribute', $model->id);
     }
 
+    public function testGetOriginal()
+    {
+        $uuid = 'cf98906e-9074-11e7-9c8e-437b4bab8527';
+        $mutator = M::mock(MutatorContract::class)
+            ->shouldReceive('get')
+            ->with('test_mutator')
+            ->andReturnSelf()
+            ->once()
+            ->shouldReceive('unserializeAttribute')
+            ->with('unserialized_attribute')
+            ->andReturn('serialized_attribute')
+            ->once()
+            ->getMock();
+
+        app()['mutator'] = $mutator;
+
+        $model = new SampleModel();
+        $original = $model->getOriginal();
+
+        $this->assertIsArray($original);
+        $this->assertEquals('serialized_attribute', $original['id']);
+    }
+
+    public function testGetOriginalProperty()
+    {
+        $uuid = 'cf98906e-9074-11e7-9c8e-437b4bab8527';
+        $mutator = M::mock(MutatorContract::class)
+            ->shouldReceive('get')
+            ->with('test_mutator')
+            ->andReturnSelf()
+            ->once()
+            ->shouldReceive('unserializeAttribute')
+            ->with('unserialized_attribute')
+            ->andReturn('serialized_attribute')
+            ->once()
+            ->getMock();
+
+        app()['mutator'] = $mutator;
+
+        $model = new SampleModel();
+        $this->assertEquals('serialized_attribute', $model->getOriginal('id'));
+    }
+
     public function testGetMutators()
     {
         $this->assertEquals(['id' => 'test_mutator'], (new SampleModel())->getMutators());

--- a/tests/Unit/Database/Traits/HasMutatorsTest.php
+++ b/tests/Unit/Database/Traits/HasMutatorsTest.php
@@ -31,7 +31,6 @@ class HasMutatorsTest extends TestCase
 
     public function testUnserializeAttribute()
     {
-        $uuid = 'cf98906e-9074-11e7-9c8e-437b4bab8527';
         $mutator = M::mock(MutatorContract::class)
             ->shouldReceive('get')
             ->with('test_mutator')
@@ -54,7 +53,6 @@ class HasMutatorsTest extends TestCase
 
     public function testGetOriginal()
     {
-        $uuid = 'cf98906e-9074-11e7-9c8e-437b4bab8527';
         $mutator = M::mock(MutatorContract::class)
             ->shouldReceive('get')
             ->with('test_mutator')
@@ -77,7 +75,6 @@ class HasMutatorsTest extends TestCase
 
     public function testGetOriginalProperty()
     {
-        $uuid = 'cf98906e-9074-11e7-9c8e-437b4bab8527';
         $mutator = M::mock(MutatorContract::class)
             ->shouldReceive('get')
             ->with('test_mutator')


### PR DESCRIPTION
### Problem
Using [`$model->getOriginal()`](https://laravel.com/docs/10.x/eloquent#examining-attribute-changes) to get the changed attributes does not correctly unserialize the values

### Changes
* Unserialize original values